### PR TITLE
added posonlyargcount to CodeType call for python >=v3.8

### DIFF
--- a/enterprise_warp/enterprise_models.py
+++ b/enterprise_warp/enterprise_models.py
@@ -626,6 +626,10 @@ def selection_factory(new_selection_name):
     list_codetype_args = list_codetype_args[:1] + \
                          [template_sel.__code__.co_kwonlyargcount] + \
                          list_codetype_args[1:]
+    if int(sys.version[2]) >= 8:
+      list_codetype_args = list_codetype_args[:1] + \
+                           [template_sel.__code__.co_posonlyargcount] + \
+                           list_codetype_args[1:]
 
   template_selection_code = types.CodeType(*list_codetype_args)
 

--- a/enterprise_warp/enterprise_models.py
+++ b/enterprise_warp/enterprise_models.py
@@ -622,14 +622,19 @@ def selection_factory(new_selection_name):
                         template_sel.__code__.co_firstlineno,
                         template_sel.__code__.co_lnotab]
 
-  if sys.version[0] == '3':
-    list_codetype_args = list_codetype_args[:1] + \
-                         [template_sel.__code__.co_kwonlyargcount] + \
-                         list_codetype_args[1:]
-    if int(sys.version[2]) >= 8:
-      list_codetype_args = list_codetype_args[:1] + \
-                           [template_sel.__code__.co_posonlyargcount] + \
-                           list_codetype_args[1:]
+  #dealing with backwards-compatibility for types.CodeType
+  sys_pyversion = float(sys.version[0:3])
+  if 3.0 < sys_pyversion < 3.8:
+    list_codetype_args_ext = [template_sel.__code__.co_kwonlyargcount]
+  elif sys_pyversion >= 3.8:
+    list_codetype_args_ext = [template_sel.__code__.co_posonlyargcount,\
+                              template_sel.__code__.co_kwonlyargcount]
+  else:
+    list_codetype_args_ext = []
+    
+  list_codetype_args = list_codetype_args[:1] + \
+                       list_codetype_args_ext + 
+                       list_codetype_args[1:]]
 
   template_selection_code = types.CodeType(*list_codetype_args)
 

--- a/enterprise_warp/enterprise_models.py
+++ b/enterprise_warp/enterprise_models.py
@@ -631,10 +631,10 @@ def selection_factory(new_selection_name):
                               template_sel.__code__.co_kwonlyargcount]
   else:
     list_codetype_args_ext = []
-    
+
   list_codetype_args = list_codetype_args[:1] + \
-                       list_codetype_args_ext + 
-                       list_codetype_args[1:]]
+                       list_codetype_args_ext + \
+                       list_codetype_args[1:]
 
   template_selection_code = types.CodeType(*list_codetype_args)
 


### PR DESCRIPTION
Hi Boris,
I've made a change in enterprise_models.py which resolves an issue with calling types.CodeType using python 3.8+.