### PR TITLE
Allow pulsar timing model parameters to be used in bilby_warp

### DIFF
--- a/enterprise_warp/bilby_warp.py
+++ b/enterprise_warp/bilby_warp.py
@@ -17,7 +17,22 @@ class PTABilbyLikelihood(bilby.Likelihood):
         self._marginalized_parameters = []
 
     def log_likelihood(self):
-        return self.pta.get_lnlikelihood(self.parameters)
+        tmparams = []
+        tmparamname = None
+        curparameters = {}
+        
+        # add timing parameters into a list
+        for param in self.parameters:
+            if "timing model_tmparams" in param:
+                tmparams.append(self.parameters[param])
+                if tmparamname is None:
+                    tmparamname = "_".join(param.split("_")[:-1])
+            else:
+                curparameters[param] = self.parameters[param]
+        if tmparamname is not None:
+            curparameters[tmparamname] = tmparams
+
+        return self.pta.get_lnlikelihood(curparameters)
 
     def get_one_sample(self):
         return {par.name: par.sample() for par in self.pta.params}
@@ -35,38 +50,52 @@ def get_bilby_prior_dict(pta):
     priors = dict()
     for param in pta.params:
 
-      if param.size==None:
-        if param.type=='uniform':
-          #priors[param.name] = bilby.core.prior.Uniform( \
-          #    param._pmin, param._pmax, param.name)
-          priors[param.name] = bilby.core.prior.Uniform( \
-              # param._pmin
-              param.prior._defaults['pmin'], param.prior._defaults['pmax'], \
-              param.name)
-        elif param.type=='normal':
-          #priors[param.name] = bilby.core.prior.Normal( \
-          #    param._mu, param._sigma, param.name)
-          priors[param.name] = bilby.core.prior.Normal( \
-              param.prior._defaults['mu'], param.prior._defaults['sigma'], \
-              param.name)
-        else:
-          raise ValueError('Unknown prior type for translation into Bilby. \
-                            Known types: Normal, Uniform.')
+        if param.size==None:
+            if param.type=='uniform':
+                #priors[param.name] = bilby.core.prior.Uniform( \
+                #    param._pmin, param._pmax, param.name)
+                priors[param.name] = bilby.core.prior.Uniform( \
+                    # param._pmin
+                    param.prior._defaults['pmin'], param.prior._defaults['pmax'], \
+                    param.name)
+            elif param.type=='normal':
+                #priors[param.name] = bilby.core.prior.Normal( \
+                #    param._mu, param._sigma, param.name)
+                priors[param.name] = bilby.core.prior.Normal( \
+                    param.prior._defaults['mu'], param.prior._defaults['sigma'], \
+                    param.name)
+            else:
+                raise ValueError(
+                    "Unknown prior type for translation into Bilby. "
+                    "Known types: Normal, Uniform."
+                )
 
-      else:
-        if param.name=='jup_orb_elements' and param.type=='uniform':
-          for ii in range(param.size):
-            priors[param.name+'_'+str(ii)] = bilby.core.prior.Uniform( \
-                -0.05, 0.05, param.name+'_'+str(ii))
         else:
-          raise ValueError('Unknown prior with non-unit size for \
-                            translation into Bilby. Known prior: \
-                            jup_orb_elements of type Uniform.')
+            print(param.name, param.type)
+            if param.name=='jup_orb_elements' and param.type=='uniform':
+                for ii in range(param.size):
+                    priors[param.name+'_'+str(ii)] = bilby.core.prior.Uniform(
+                        -0.05, 0.05, param.name+'_'+str(ii)
+                    )
+            elif "timing model_tmparams" in param.name and param.type == "uniform":
+                for ii in range(param.size):
+                    priors[param.name + "_" + str(ii)] = bilby.core.prior.Uniform(
+                        param.prior._defaults['pmin'],
+                        param.prior._defaults['pmax'],
+                        param.name + "_" + str(ii)
+                    )
+            else:
+                raise ValueError(
+                    "Unknown prior with non-unit size for "
+                    "translation into Bilby. Known prior: "
+                    "jup_orb_elements or tmparams of type "
+                    "Uniform."
+                )
 
     # Consistency check
     for key, val in priors.items():
         if key not in pta.param_names:
-          print('[!] Warning: Bilby\'s ',key,' is not in PTA params:',\
-              pta.param_names)
+            print('[!] Warning: Bilby\'s ',key,' is not in PTA params:',\
+                  pta.param_names)
 
-    return priors 
+    return priors

--- a/examples/bilby_example.py
+++ b/examples/bilby_example.py
@@ -37,6 +37,7 @@ model = ef + tm
 pta = signal_base.PTA([model(psrs[0])])
 
 priors = bilby_warp.get_bilby_prior_dict(pta)
+
 parameters = dict.fromkeys(priors.keys())
 likelihood = bilby_warp.PTABilbyLikelihood(pta,parameters)
 label = 'test_bilby'


### PR DESCRIPTION
I've made some minor modifcations to bilby_warp to try and allow estimate of pulsar timing model parameters assuming use of a [`timing_block`](https://github.com/nanograv/enterprise_extensions/blob/master/enterprise_extensions/timing.py#L52) from enterprise_extensions timing.py module.